### PR TITLE
chore: deprecate set-env for $GITHUB_PATH

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
           python get-poetry.py -y
-          echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
       - name: Set up cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
           python get-poetry.py -y
-          echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
       - name: Set up cache

--- a/{{cookiecutter.repo_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
           python get-poetry.py -y
-          echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
       - name: Set up cache

--- a/{{cookiecutter.repo_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
           python get-poetry.py -y
-          echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
       - name: Set up cache


### PR DESCRIPTION
deprecation ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
ref: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path